### PR TITLE
v3.0.2 - Fix parsing of 1rem / 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.2
+- Fix parsing of `1rem / 1.2` when the slash is surrounded by spaces.
+
 ## 3.0.1
 - Fix readme.
 - Add `package-lock.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-css-font",
-  "version": "2.0.2",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -127,9 +127,9 @@
       }
     },
     "@types/node": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.3.tgz",
-      "integrity": "sha512-J7nx6JzxmtT4zyvfLipYL7jNaxvlCWpyG7JhhCQ4fQyG+AGfovAHoYR55TFx+X8akfkUJYpt5JG6GPeFMjZaCQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
+      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA==",
       "dev": true
     },
     "ansi-align": {
@@ -1576,14 +1576,13 @@
       "dev": true
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
+        "randomatic": "^3.0.0",
         "repeat-element": "^1.1.2",
         "repeat-string": "^1.5.2"
       }
@@ -2445,8 +2444,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2549,7 +2547,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -2635,8 +2632,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -2648,7 +2644,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       }
@@ -2697,7 +2692,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2862,6 +2856,11 @@
       "requires": {
         "escape-string-regexp": "^1.0.4"
       }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
     },
     "md5-hex": {
       "version": "2.0.0",
@@ -3105,9 +3104,9 @@
       "dev": true
     },
     "nyc": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.7.1.tgz",
-      "integrity": "sha512-EGePURSKUEpS1jWnEKAMhY+GWZzi7JC+f8iBDOATaOsLZW5hM/9eYx2dHGaEXa1ITvMm44CJugMksvP3NwMQMw==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.8.0.tgz",
+      "integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
@@ -3127,11 +3126,11 @@
         "istanbul-lib-source-maps": "^1.2.3",
         "istanbul-reports": "^1.4.0",
         "md5-hex": "^1.2.0",
-        "merge-source-map": "^1.0.2",
-        "micromatch": "^2.3.11",
+        "merge-source-map": "^1.1.0",
+        "micromatch": "^3.1.10",
         "mkdirp": "^0.5.0",
         "resolve-from": "^2.0.0",
-        "rimraf": "^2.5.4",
+        "rimraf": "^2.6.2",
         "signal-exit": "^3.0.1",
         "spawn-wrap": "^1.4.2",
         "test-exclude": "^4.2.0",
@@ -3178,12 +3177,9 @@
           "dev": true
         },
         "arr-diff": {
-          "version": "2.0.0",
+          "version": "4.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
+          "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
@@ -3196,7 +3192,7 @@
           "dev": true
         },
         "array-unique": {
-          "version": "0.2.1",
+          "version": "0.3.2",
           "bundled": true,
           "dev": true
         },
@@ -3216,7 +3212,7 @@
           "dev": true
         },
         "atob": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true
         },
@@ -3381,13 +3377,30 @@
           }
         },
         "braces": {
-          "version": "1.8.5",
+          "version": "2.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
         "builtin-modules": {
@@ -3541,7 +3554,7 @@
           "dev": true
         },
         "core-js": {
-          "version": "2.5.5",
+          "version": "2.5.6",
           "bundled": true,
           "dev": true
         },
@@ -3685,19 +3698,35 @@
           }
         },
         "expand-brackets": {
-          "version": "0.1.5",
+          "version": "2.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fill-range": "^2.1.0"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
         "extend-shallow": {
@@ -3720,28 +3749,88 @@
           }
         },
         "extglob": {
-          "version": "0.3.2",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
-        "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "fill-range": {
-          "version": "2.2.3",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^1.1.3",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
           }
         },
         "find-cache-dir": {
@@ -3766,14 +3855,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.1"
-          }
         },
         "foreground-child": {
           "version": "1.5.6",
@@ -3823,23 +3904,6 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-parent": "^2.0.0",
-            "is-glob": "^2.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
           }
         },
         "globals": {
@@ -4028,26 +4092,8 @@
             }
           }
         },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-primitive": "^2.0.0"
-          }
-        },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -4064,16 +4110,8 @@
           "bundled": true,
           "dev": true
         },
-        "is-glob": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
         "is-number": {
-          "version": "2.1.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4110,16 +4148,6 @@
             }
           }
         },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "is-stream": {
           "version": "1.1.0",
           "bundled": true,
@@ -4146,12 +4174,9 @@
           "dev": true
         },
         "isobject": {
-          "version": "2.1.0",
+          "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
+          "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
@@ -4292,7 +4317,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
+          "version": "4.17.10",
           "bundled": true,
           "dev": true
         },
@@ -4310,7 +4335,7 @@
           }
         },
         "lru-cache": {
-          "version": "4.1.2",
+          "version": "4.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4368,23 +4393,30 @@
           }
         },
         "micromatch": {
-          "version": "2.3.11",
+          "version": "3.1.10",
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "mimic-fn": {
@@ -4484,14 +4516,6 @@
             "validate-npm-package-license": "^3.0.1"
           }
         },
-        "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        },
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
@@ -4543,15 +4567,6 @@
               "bundled": true,
               "dev": true
             }
-          }
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-own": "^0.1.4",
-            "is-extendable": "^0.1.1"
           }
         },
         "object.pick": {
@@ -4626,17 +4641,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-base": "^0.3.0",
-            "is-dotfile": "^1.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.0"
-          }
         },
         "parse-json": {
           "version": "2.2.0",
@@ -4726,52 +4730,10 @@
           "bundled": true,
           "dev": true
         },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
         "pseudomap": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -4808,14 +4770,6 @@
           "bundled": true,
           "dev": true
         },
-        "regex-cache": {
-          "version": "0.4.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-equal-shallow": "^0.1.3"
-          }
-        },
         "regex-not": {
           "version": "1.0.2",
           "bundled": true,
@@ -4824,11 +4778,6 @@
             "extend-shallow": "^3.0.2",
             "safe-regex": "^1.1.0"
           }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
@@ -5740,7 +5689,7 @@
               "dev": true
             },
             "cliui": {
-              "version": "4.0.0",
+              "version": "4.1.0",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -6113,43 +6062,24 @@
       "dev": true
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -6326,14 +6256,12 @@
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-css-font",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Parse the CSS font property value.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -63,10 +63,10 @@
     "unquote": "^1.1.1"
   },
   "devDependencies": {
-    "@types/node": "^10.0.3",
+    "@types/node": "^10.1.2",
     "ava": "^0.25.0",
     "concurrently": "^3.5.1",
-    "nyc": "^11.7.1",
+    "nyc": "^11.8.0",
     "rimraf": "^2.6.2",
     "tslint": "^5.10.0",
     "typescript": "^2.8.3"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -70,6 +70,16 @@ test('detects line-height: 1.2', (t) => {
 	);
 });
 
+test('detects font-size and line-height when using spaces around "/" separator', (t) => {
+	compare(t,
+		parse('1rem / 1.2 serif'),
+		{
+			lineHeight: 1.2,
+			size: '1rem',
+		},
+	);
+});
+
 test('preserves line-height unit', (t) => {
 	compare(t,
 		parse('1rem/1.2em serif'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,9 @@ export default function parseCSSFont(value: string) {
 			font.size = parts[0];
 			if (!!parts[1]) {
 				font.lineHeight = parseLineHeight(parts[1]);
+			} else if (tokens[0] === '/') {
+				tokens.shift();
+				font.lineHeight = parseLineHeight(tokens.shift() as string);
 			}
 			if (!tokens.length) {
 				throw error('Missing required font-family.');


### PR DESCRIPTION
Fixes #7 

## 3.0.2
- Fix parsing of `1rem / 1.2` when the slash is surrounded by spaces.