### PR TITLE
support for parsing arbitrary weight numbers and stretch percentages

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,8 +1,39 @@
+const fontWeightKeywords = require('css-font-weight-keywords');
 const cssFontSizeKeywords = require('css-font-size-keywords');
+const fontStretchKeywords = require('css-font-stretch-keywords');
 
 export function isSize(value: string) {
-	return /^[\d\.]/.test(value)
+	return /^\+?[\d\.]/.test(value)
 		|| value.indexOf('/') !== -1
 		|| cssFontSizeKeywords.indexOf(value) !== -1
 	;
+}
+
+export function isWeight(value: string) {
+	return fontWeightKeywords.indexOf(value) !== -1
+		|| isOnlyNumber(value, false);
+}
+
+export function isStretch(value: string) {
+	return fontStretchKeywords.indexOf(value) !== -1
+		|| isOnlyNumber(value, true);
+}
+
+function isOnlyNumber(value: string, isPercent: boolean): boolean {
+	const match = /^(\+|-)?(\d|\.)/.exec(value);
+	if (match && (!isPercent || /%$/.test(value))) {
+		let val = isPercent ? value.substring(0, value.length - 1) : value;
+		if (match[1] === '+') {
+			val = val.substring(1);
+		}
+		if (match[2] === '.') {
+			if (match[1] === '-') {
+				val = '-0' + val.substring(1);
+			} else {
+				val = '0' + val;
+			}
+		}
+		return parseFloat(val).toString() === val;
+	}
+	return false;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,7 +3,7 @@ const cssFontSizeKeywords = require('css-font-size-keywords');
 const fontStretchKeywords = require('css-font-stretch-keywords');
 
 const sizePattern = /^\+?[\d\.]/;
-const numberPrefixPattern = /^(\+|-)?(\d|\.)/;
+const numberPrefixPattern = /^(\+|-)?(\.)?\d/;
 const percentPattern = /%$/;
 
 export function isSize(value: string) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,8 +2,12 @@ const fontWeightKeywords = require('css-font-weight-keywords');
 const cssFontSizeKeywords = require('css-font-size-keywords');
 const fontStretchKeywords = require('css-font-stretch-keywords');
 
+const sizePattern = /^\+?[\d\.]/;
+const numberPrefixPattern = /^(\+|-)?(\d|\.)/;
+const percentPattern = /%$/;
+
 export function isSize(value: string) {
-	return /^\+?[\d\.]/.test(value)
+	return sizePattern.test(value)
 		|| value.indexOf('/') !== -1
 		|| cssFontSizeKeywords.indexOf(value) !== -1
 	;
@@ -11,29 +15,36 @@ export function isSize(value: string) {
 
 export function isWeight(value: string) {
 	return fontWeightKeywords.indexOf(value) !== -1
-		|| isOnlyNumber(value, false);
+		|| isOnlyNumber(value);
 }
 
 export function isStretch(value: string) {
 	return fontStretchKeywords.indexOf(value) !== -1
-		|| isOnlyNumber(value, true);
+		|| isOnlyPercentNumber(value);
 }
 
-function isOnlyNumber(value: string, isPercent: boolean): boolean {
-	const match = /^(\+|-)?(\d|\.)/.exec(value);
-	if (match && (!isPercent || /%$/.test(value))) {
-		let val = isPercent ? value.substring(0, value.length - 1) : value;
-		if (match[1] === '+') {
-			val = val.substring(1);
-		}
-		if (match[2] === '.') {
-			if (match[1] === '-') {
-				val = '-0' + val.substring(1);
-			} else {
-				val = '0' + val;
-			}
-		}
-		return parseFloat(val).toString() === val;
+function isOnlyPercentNumber(value: string): boolean {
+	if (percentPattern.test(value)) {
+		return isOnlyNumber(value.substring(0, value.length - 1));
 	}
 	return false;
+}
+
+function isOnlyNumber(value: string): boolean {
+	const match = numberPrefixPattern.exec(value);
+	if (!match) {
+		return false;
+	}
+	const [, sign, dot] = match;
+	if (sign === '+') {
+		value = value.substring(1);
+	}
+	if (dot === '.') {
+		if (sign === '-') {
+			value = '-0' + value.substring(1);
+		} else {
+			value = '0' + value;
+		}
+	}
+	return parseFloat(value).toString() === value;
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,23 +7,51 @@ const fontStyleKeywords = require('css-font-style-keywords');
 const fontStretchKeywords = require('css-font-stretch-keywords');
 
 const numberValues = [
-	'1', '56', '22.876', '87', '99.999999999', '100.6',
-	'123', '200.89', '23.300569', '321', '254', '328.907',
+	'1',
+	'56',
+	'22.876',
+	'87',
+	'99.999999999',
+	'100.6',
+	'123',
+	'200.89',
+	'23.300569',
+	'321',
+	'254',
+	'328.907',
 ];
 
-// A <number> value between 1 and 1000, inclusive.
-const fontWeightNumberValues = numberValues.slice().concat(['999', '999.999999999']);
+const fontWeightNumberValues = numberValues.concat([
+	'999',
+	'999.999999999',
+]);
 
-// A <number> value outside of range 1 and 1000, inclusive.
-const invalidFontWeightNumberValues = ['0.1', '.34556', '1000.0000000000001', '23423456'];
+const invalidFontWeightNumberValues = [
+	'0.1',
+	'.34556',
+	'1000.0000000000001',
+	'23423456',
+];
 
-// A <percentage> value. Negative values are not allowed for this property.
-const fontStetchPercentValues = numberValues.map((val) => val + '%').concat(['.256%', '0.75%', '+.8%', '+26.8%']);
+const fontStetchPercentValues = numberValues.concat([
+	'.256',
+	'0.75',
+	'+.8',
+	'+26.8',
+]).map((val) => val + '%');
 
-// A negative <percentage> value.
-const invalidFontStetchPercentValues = numberValues.map((val) => '-' + val + '%').concat(['-.234%', '-53%']);
+const invalidFontStetchPercentValues = numberValues.concat([
+	'.234',
+	'53',
+]).map((val) => `-${val}%`);
 
-const lineHeightNumberValues = numberValues.slice().concat(['.256', '0.75', '+.8', '+26.8']);
+const lineHeightNumberValues = numberValues.concat([
+	'.256',
+	'0.75',
+	'+.8',
+	'+26.8',
+]);
+
 const unitAndPercentNumberValues = numberValues.map((val) => val + '%')
 		.concat(numberValues.map((val) => val + 'rem'))
 		.concat(numberValues.map((val) => val + 'em'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,19 +140,18 @@ function parseLineHeight(value: string) {
 	const parsed = parseFloat(value);
 	if (parsed.toString() === value) {
 		return parsed;
-	} else {
-		const match = /^(\+)?(\.)?/.exec(value) as RegExpExecArray;
-		let val: string = value;
-		const [, sign, dot] = match;
-		if (sign === '+') {
-			val = val.substring(1);
-		}
-		if (dot === '.') {
-			val = '0' + val;
-		}
-		if (parsed.toString() === val) {
-			return parsed;
-		}
+	}
+	const match = /^(\+)?(\.)?/.exec(value);
+	let val: string = value;
+	const [, sign, dot] = match;
+	if (sign === '+') {
+		val = val.substring(1);
+	}
+	if (dot === '.') {
+		val = '0' + val;
+	}
+	if (parsed.toString() === val) {
+		return parsed;
 	}
 	return value;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,17 +63,14 @@ export default function parseCSSFont(value: string) {
 			if (isLocked) {
 				continue;
 			}
-			if (fontWeightKeywords.indexOf(token) !== -1) {
-				font.weight = token;
-				continue;
-			} else {
+			if (fontWeightKeywords.indexOf(token) === -1) {
 				const num = parseFloat(token);
 				if (num < 1 || num > 1000) {
 					throw error('Invalid font-weight value: must be between 1 and 1000 (inclusive).');
 				}
-				font.weight = token;
-				continue;
 			}
+			font.weight = token;
+			continue;
 		}
 
 		if (fontStyleKeywords.indexOf(token) !== -1) {
@@ -88,14 +85,11 @@ export default function parseCSSFont(value: string) {
 			if (isLocked) {
 				continue;
 			}
-			if (fontStretchKeywords.indexOf(token) !== -1) {
-				font.stretch = token;
-				continue;
-			} else {
+			if (fontStretchKeywords.indexOf(token) === -1) {
 				prelimStretchNum = true;
-				font.stretch = token;
-				continue;
 			}
+			font.stretch = token;
+			continue;
 		}
 
 		if (helpers.isSize(token)) {
@@ -110,7 +104,7 @@ export default function parseCSSFont(value: string) {
 			if (!tokens.length) {
 				throw error('Missing required font-family.');
 			}
-			font.family = cssListHelpers.splitByCommas(tokens.join(' ')).map(unquote) as string[];
+			font.family = cssListHelpers.splitByCommas(tokens.join(' ')).map(unquote);
 			if (prelimStretchNum) {
 				const num = parseFloat(font.stretch as string);
 				if (num < 0) {
@@ -121,7 +115,7 @@ export default function parseCSSFont(value: string) {
 		} else if (prelimStretchNum) {
 			font.size = font.stretch;
 			font.stretch = 'normal';
-			font.family = cssListHelpers.splitByCommas(tokens.join(' ')).map(unquote) as string[];
+			font.family = cssListHelpers.splitByCommas(tokens.join(' ')).map(unquote);
 			return font;
 		}
 
@@ -147,18 +141,14 @@ function parseLineHeight(value: string) {
 	if (parsed.toString() === value) {
 		return parsed;
 	} else {
-		const match = /^(\+|-)?(\.)?/.exec(value) as RegExpMatchArray;
+		const match = /^(\+)?(\.)?/.exec(value) as RegExpMatchArray;
 		let val: string = value;
-		if (match[1] === '+') {
+		const [, sign, dot] = match;
+		if (sign === '+') {
 			val = val.substring(1);
 		}
-		if (match[2] === '.') {
-				// NOTE although not specifically prohibited, we do not consider negative numbers for line-height valid:
-			// if (match[1] === '-') {
-			// 	val = '-0' + val.substring(1);
-			// } else {
-				val = '0' + val;
-			// }
+		if (dot === '.') {
+			val = '0' + val;
 		}
 		if (parsed.toString() === val) {
 			return parsed;

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ function parseLineHeight(value: string) {
 	if (parsed.toString() === value) {
 		return parsed;
 	} else {
-		const match = /^(\+)?(\.)?/.exec(value) as RegExpMatchArray;
+		const match = /^(\+)?(\.)?/.exec(value) as RegExpExecArray;
 		let val: string = value;
 		const [, sign, dot] = match;
 		if (sign === '+') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
+		"downlevelIteration": true,
 		"noUnusedLocals": true
   },
   "exclude": [


### PR DESCRIPTION
adds support for parsing extended capabilities defined in _CSS Fonts Module Level 4_ for

 * `font-weight`: allow arbitrary numbers from 1 to 1000
    * https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
    * https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-number
 * `font-stretch`: allow (positive) percentage numbers
  * https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch
  * https://drafts.csswg.org/css-fonts-4/#valdef-font-stretch-percentage

this PR also extends parsing of valid numbers:
namely considering leading `+` and `-` when parsing numbers
See also
https://developer.mozilla.org/en-US/docs/Web/CSS/integer
https://drafts.csswg.org/css-values-3/#numeric-types